### PR TITLE
SB-193: Add ability to designate target API version when loading a SheerID instance

### DIFF
--- a/sheerid/sheerid.py
+++ b/sheerid/sheerid.py
@@ -221,7 +221,7 @@ class SheerID:
         return "%s/rest/%s%s" % (self.base_url, self.target_version, path)
 
     @classmethod
-    def load_instance(cls, name, verbose=False, insecure=False):
+    def load_instance(cls, name, verbose=False, insecure=False, target_version="0.5"):
         names = name.split(":")
         master = names[0]
         puppet = None
@@ -256,7 +256,7 @@ class SheerID:
                 except IOError:
                     access_token += ('/' + puppet)
 
-            return SheerID(access_token, base_url, verbose=verbose, insecure=insecure)
+            return SheerID(access_token, base_url, target_version=target_version, verbose=verbose, insecure=insecure)
         except KeyError:
             return None
 


### PR DESCRIPTION
This allows us to target other APIs besides 0.5. For example, to target the `internal` API, we'd use target_version `internal`